### PR TITLE
Fix Azure commercial RKE2 deployments

### DIFF
--- a/modules/custom_data/files/rke2-init.sh
+++ b/modules/custom_data/files/rke2-init.sh
@@ -124,8 +124,6 @@ upload() {
     ((retries--))
   done
 
-  cat /etc/rancher/rke2/rke2.yaml
-
   azure_domain=$(get_azure_kv_domain)
 
   access_token=$(curl "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.$${azure_domain}" -H Metadata:true | jq -r ".access_token")

--- a/modules/custom_data/files/rke2-init.sh
+++ b/modules/custom_data/files/rke2-init.sh
@@ -40,6 +40,14 @@ get_azure_domain() {
   fi
 }
 
+get_azure_kv_domain() {
+  if [ "$CLOUD" = "AzureUSGovernmentCloud" ]; then
+    echo 'usgovcloudapi.net'
+  else
+    echo 'azure.net'
+  fi
+}
+
 # The most simple "leader election" you've ever seen in your life
 elect_leader() {
 
@@ -96,7 +104,7 @@ cp_wait() {
 fetch_token() {
   info "Fetching rke2 join token..."
 
-  azure_domain=$(get_azure_domain)
+  azure_domain=$(get_azure_kv_domain)
 
   access_token=$(curl "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.$${azure_domain}" -H Metadata:true | jq -r ".access_token")
   token=$(curl '${vault_url}secrets/${token_secret}?api-version=2016-10-01' -H "Authorization: Bearer $${access_token}" | jq -r ".value")
@@ -116,7 +124,9 @@ upload() {
     ((retries--))
   done
 
-  azure_domain=$(get_azure_domain)
+  cat /etc/rancher/rke2/rke2.yaml
+
+  azure_domain=$(get_azure_kv_domain)
 
   access_token=$(curl "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.$${azure_domain}" -H Metadata:true | jq -r ".access_token")
 

--- a/modules/rke2-server/main.tf
+++ b/modules/rke2-server/main.tf
@@ -131,7 +131,8 @@ module "init" {
   ccm           = var.enable_ccm
   node_labels   = "[]"
   #node_labels   = "[\"failure-domain.beta.kubernetes.io/region=${data.azurerm_resource_group.rg.location}\"]"
-  node_taints = "[\"CriticalAddonsOnly=true:NoExecute\"]"
+  node_taints   = "[\"CriticalAddonsOnly=true:NoExecute\"]"
+  cloud         = var.cloud
 
   agent = false
 }


### PR DESCRIPTION
There were two issues:

* Firstly, rke2-server did not properly pass down `var.cloud` variable, resulting in the rke2-init.sh script using the default value of AzureUSGovernmentCloud.
* Secondly, once this was fixed, the rke2-init.sh script erroneously supposed that all azure domains in Public cloud are azure.com. Key Vault is azure.net - so, introduced another method just for key vault to get the proper domain.